### PR TITLE
Switch from GitHub Super Linter to chktex

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/base:bullseye
 # ** [Optional] Uncomment this section to install additional packages. **
 # hadolint ignore=DL3008
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends texlive-full texlive-base rubber rcm \
+    && apt-get -y install --no-install-recommends texlive-full texlive-base rubber \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Debian version: buster, stretch
-FROM mcr.microsoft.com/vscode/devcontainers/base:bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/base:bookworm
 
 # ** [Optional] Uncomment this section to install additional packages. **
 # hadolint ignore=DL3008

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,13 +3,54 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-insert_final_newline = true
 indent_style = space
+indent_size = 4
+
+[*.bib]
+trim_trailing_whitespace = false
+
+# Use 2 spaces for the Markdown files
+[*.md]
 indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 80
+
+# Docstrings and comments use max_line_length = 79
+[*.py]
+insert_final_newline = true
+max_line_length = 127
 trim_trailing_whitespace = true
 
+[*.rst]
+indent_size = 2
+insert_final_newline = true
+max_line_length = 127
+trim_trailing_whitespace = true
+
+# Use 2 spaces for the HTML files
+[*.html]
+indent_size = 2
+
+# The JSON files contain newlines inconsistently
+[*.json]
+trim_trailing_whitespace = true
+
+# Makefiles always use tabs for indentation
 [Makefile]
 indent_style = tab
+insert_final_newline = true
 
-[*.{bib,md}]
-trim_trailing_whitespace = false
+# Batch files use tabs for indentation
+[*.bat]
+indent_style = tab
+insert_final_newline = true
+
+[docs/**.txt]
+insert_final_newline = true
+max_line_length = 79
+
+[*.{yml,yaml}]
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,20 @@
 ---
 version: 2
 updates:
-  - package-ecosystem: docker
-    directory: /.devcontainer
+  - package-ecosystem: devcontainers
+    directory: /
     schedule:
       interval: monthly
-    open-pull-requests-limit: 10
+    groups:
+      devcontainer:
+        patterns:
+          - "*"
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: monthly
-    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,2 +1,0 @@
----
-_extends: .github:.github/stale.yml

--- a/.github/workflows/latex-ci.yml
+++ b/.github/workflows/latex-ci.yml
@@ -13,11 +13,14 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Run chktex
+      - name: Install chktex
         run: |
           sudo apt-get update
           sudo apt-get install -y chktex
-          chktex -q -n 6 *.tex
+
+      - name: Run chktex
+        run: |
+          chktex -q -n 6 `git ls-files '*.tex'`
 
   build-test:
     needs: lint

--- a/.github/workflows/latex-ci.yml
+++ b/.github/workflows/latex-ci.yml
@@ -13,6 +13,24 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pymarkdownlnt yamllint
+
+      - name: Lint with yamllint
+        run: |
+          yamllint . --format github
+
+      - name: Lint with pymarkdownlint
+        run: |
+          pymarkdownlnt scan `git ls-files '*.md' ':!:*TEMPLATE/*md'`
+
       - name: Install chktex
         run: |
           sudo apt-get update

--- a/.github/workflows/latex-ci.yml
+++ b/.github/workflows/latex-ci.yml
@@ -7,23 +7,17 @@ on:
 jobs:
   lint:
     name: Lint Code Base
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Lint Code Base
-        uses: github/super-linter@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_ALL_CODEBASE: false
-          VALIDATE_ENV: true
-          VALIDATE_JSON: true
-          VALIDATE_LATEX: true
-          VALIDATE_MARKDOWN: true
-          VALIDATE_XML: true
-          VALIDATE_YAML: true
+      - name: Run chktex
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y chktex
+          chktex -q -n 6 *.tex
 
   build-test:
     needs: lint

--- a/.pymarkdown.yml
+++ b/.pymarkdown.yml
@@ -1,0 +1,6 @@
+---
+plugins:
+  md013:
+    enabled: false
+  md024:
+    enabled: false

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,11 +18,6 @@
       "group": "buid",
       "type": "shell",
       "command": "rubber -d presentation.tex"
-    },
-    {
-      "label": "Refresh rfc.bib",
-      "type": "shell",
-      "command": "curl --silent -k -o rfc.bib https://tm.uka.de/~bless/rfc.bib"
     }
   ]
 }


### PR DESCRIPTION
Updating template repository to stop using GitHub Super Linter as in #53 and switch to `chktex` for TeX files. A future change it required in `.github/workflows/latex-ci.yml` to remove the pin on Ubuntu 24.04 and it tracked in #56.

from:
```
jobs:
  lint:
    name: Lint Code Base
    runs-on: ubuntu-24.04
```

to:
```
jobs:
  lint:
    name: Lint Code Base
    runs-on: ubuntu-latest
```